### PR TITLE
Fix CLI tests for newer Click

### DIFF
--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -14,7 +14,7 @@ class CliTestSuite(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         self.runner = runner
 
     def test_help_option(self):
@@ -41,5 +41,4 @@ class CliTestSuite(unittest.TestCase):
         # Allow for minor differences between funowl and py-horned-owl
         axiom_diff = abs(len(axioms) - len(expected_axioms))
         assert axiom_diff <= 2, f"Axiom count difference too large: {len(axioms)} vs {len(expected_axioms)}"
-
 


### PR DESCRIPTION
## Summary
- remove the deprecated/removed `mix_stderr` argument from CLI test runner setup
- keep dependency constraints unchanged so this remains compatible with current locked dependencies and newer Click versions

## Tests
- `env -u VIRTUAL_ENV poetry install && env -u VIRTUAL_ENV make test`